### PR TITLE
Fix syntax error on formResourcesPattern

### DIFF
--- a/camunda-engine-rest-client-openapi-springboot/src/main/java/org/camunda/community/rest/client/springboot/CamundaProcessAutodeployment.java
+++ b/camunda-engine-rest-client-openapi-springboot/src/main/java/org/camunda/community/rest/client/springboot/CamundaProcessAutodeployment.java
@@ -38,7 +38,7 @@ public class CamundaProcessAutodeployment {
     @Value("${camunda.autoDeploy.dmnResources:}")
     private String dmnResourcesPattern;
 
-    @Value("${camunda.autoDeploy.formResources:")
+    @Value("${camunda.autoDeploy.formResources:}")
     private String formResourcesPattern;
 
     @Value("${spring.application.name:spring-app}")


### PR DESCRIPTION
Using version 7.17.2 I get the error `Could not open ServletContext resource [/${camunda.autoDeploy.formResources:]`due to a malformed `@Value` in `CamundaProcessAutodeployment`