### PR TITLE
Enable flag to turn off auto deploy

### DIFF
--- a/camunda-engine-rest-client-openapi-springboot/src/main/java/org/camunda/community/rest/client/springboot/CamundaProcessAutodeployment.java
+++ b/camunda-engine-rest-client-openapi-springboot/src/main/java/org/camunda/community/rest/client/springboot/CamundaProcessAutodeployment.java
@@ -49,8 +49,14 @@ public class CamundaProcessAutodeployment {
     @Value("${spring.application.name:spring-app}")
     private String applicationName;
 
+    @Value("${camunda.autoDeploy.enabled:true}")
+    private boolean autoDeployEnabled;
+
     @PostConstruct
     public void deployCamundaResources() throws IOException, ApiException {
+        if(!autoDeployEnabled){
+            return;
+        }
         if (bpmnResourcesPattern==null || bpmnResourcesPattern.length()==0) {
             bpmnResourcesPattern = "classpath*:**/*.bpmn"; // Not sure why the default mechanism in @Value makes problems - but this works!
         }


### PR DESCRIPTION
Currently there isn't a way to turn off auto deployment. I had explicit issue while having IT test in java where it is trying to deploy the bpmn to endpoint which is ofcorse not available. Setting the flag `camunda.autoDeploy.enabled` it can be turned off, which is defaulted to true to keep current behavior intact.