### PR TITLE
Enable feature key to let service start / boot if deployment fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ You can disable auto deployment (which is enabled by default):
 camunda.autoDeploy.enabled: false
 ```
 
+If you want to disable service start failure if it fails during deployment of the resource (which is enabled by default): 
+```
+camunda.autoDeploy.failStartupOnError: false
+```
 
 ### Spring Boot OpenAPI + External Task Bundle
 


### PR DESCRIPTION
Currently if auto deploy fails for any reason like lets say engine is down, the service fails to boot. We can have an option to change the behaviors and just logs an error. Default functionality will continue to work as it does today.

Fixing https://github.com/camunda-community-hub/camunda-platform-7-rest-client-java/issues/54