### PR TITLE
Change openApi generator dateFormat to java8

### DIFF
--- a/camunda-engine-rest-client-openapi-java/pom.xml
+++ b/camunda-engine-rest-client-openapi-java/pom.xml
@@ -90,7 +90,7 @@
                 <apiPackage>org.camunda.community.rest.client.api</apiPackage>
                 <invokerPackage>org.camunda.community.rest.client.invoker</invokerPackage>
                 <modelPackage>org.camunda.community.rest.client.dto</modelPackage>
-                <dateLibrary>legacy</dateLibrary>
+                <dateLibrary>java8</dateLibrary>
                 <sourceFolder>src/gen/java/main</sourceFolder>
               </configOptions>
             </configuration>


### PR DESCRIPTION
Camunda rest api only allows dates in the format `yyyy-MM-dd'T'HH:mm:ss.SSSZ`
This PR is to allow the client to accept dates in the right format

closes #72 