### PR TITLE
move to apache http client

### DIFF
--- a/camunda-engine-rest-client-complete-springboot-starter/pom.xml
+++ b/camunda-engine-rest-client-complete-springboot-starter/pom.xml
@@ -14,13 +14,11 @@
 		<dependency>
 		  <groupId>org.camunda.community</groupId>
 		  <artifactId>camunda-engine-rest-client-openapi-springboot</artifactId>
-		  <version>${project.version}</version>
 		</dependency>
 		<!-- Open API client -->
 		<dependency>
 		  <groupId>org.camunda.bpm.springboot</groupId>
 		  <artifactId>camunda-bpm-spring-boot-starter-external-task-client</artifactId>
-		  <version>${camunda.version}</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/camunda-engine-rest-client-openapi-java/pom.xml
+++ b/camunda-engine-rest-client-openapi-java/pom.xml
@@ -10,63 +10,55 @@
 
   <artifactId>camunda-engine-rest-client-openapi-java</artifactId>
 
-  <dependencies> 
-  
-    <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>2.9.0</version>
-    </dependency>
+  <dependencies>
+
+    <!-- @Nullable annotation -->
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
     </dependency>
 
+
+    <!-- HTTP client: apache client -->
     <dependency>
-      <groupId>org.threeten</groupId>
-      <artifactId>threetenbp</artifactId>
-      <version>1.6.0</version>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
     </dependency>
 
+    <!-- JSON processing: jackson -->
     <dependency>
-      <groupId>com.squareup.okio</groupId>
-      <artifactId>okio</artifactId>
-      <version>2.10.0</version>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>okhttp</artifactId>
-      <version>4.9.3</version>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>logging-interceptor</artifactId>
-      <version>4.9.3</version>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
-
     <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <version>1.3.2</version>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
     </dependency>
-
     <dependency>
-      <groupId>io.swagger</groupId>
-      <artifactId>swagger-annotations</artifactId>
-      <version>1.6.6</version>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
-
     <dependency>
-      <groupId>io.gsonfire</groupId>
-      <artifactId>gson-fire</artifactId>
-      <version>1.8.5</version>
+      <groupId>org.openapitools</groupId>
+      <artifactId>jackson-databind-nullable</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <!-- test dependencies -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -76,7 +68,6 @@
       <plugin>
         <groupId>org.openapitools</groupId>
         <artifactId>openapi-generator-maven-plugin</artifactId>
-        <version>5.1.0</version>
         <executions>
           <execution>
             <goals>
@@ -90,8 +81,9 @@
                 <apiPackage>org.camunda.community.rest.client.api</apiPackage>
                 <invokerPackage>org.camunda.community.rest.client.invoker</invokerPackage>
                 <modelPackage>org.camunda.community.rest.client.dto</modelPackage>
-                <dateLibrary>legacy</dateLibrary>
-                <sourceFolder>src/gen/java/main</sourceFolder>
+                <library>apache-httpclient</library>
+                <dateLibrary>java8</dateLibrary>
+                <testOutput>${project.build.directory}/generated-test-sources/openapi</testOutput>
               </configOptions>
             </configuration>
           </execution>

--- a/camunda-engine-rest-client-openapi-springboot/pom.xml
+++ b/camunda-engine-rest-client-openapi-springboot/pom.xml
@@ -13,22 +13,23 @@
 		<dependency>
 		  <groupId>org.camunda.community</groupId>
 		  <artifactId>camunda-engine-rest-client-openapi-java</artifactId>
-		  <version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
-			<version>${springboot.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.11.0</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.xml.bind</groupId>
 			<artifactId>jaxb-api</artifactId>
-			<version>2.3.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/camunda-engine-rest-client-openapi-springboot/src/main/java/org/camunda/community/rest/client/springboot/CamundaApi.java
+++ b/camunda-engine-rest-client-openapi-springboot/src/main/java/org/camunda/community/rest/client/springboot/CamundaApi.java
@@ -25,7 +25,7 @@ public class CamundaApi {
 
     @Bean
     public ConditionApi conditionApi() {
-        return new ConditionApi();
+        return new ConditionApi(apiClient);
     }
 
     @Bean

--- a/camunda-engine-rest-client-openapi-springboot/src/test/java/org/camunda/community/rest/client/springboot/AppTest.java
+++ b/camunda-engine-rest-client-openapi-springboot/src/test/java/org/camunda/community/rest/client/springboot/AppTest.java
@@ -1,0 +1,13 @@
+package org.camunda.community.rest.client.springboot;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class AppTest {
+
+  @Test
+  void shouldRun() {
+
+  }
+}

--- a/camunda-engine-rest-client-openapi-springboot/src/test/java/org/camunda/community/rest/client/springboot/TestApp.java
+++ b/camunda-engine-rest-client-openapi-springboot/src/test/java/org/camunda/community/rest/client/springboot/TestApp.java
@@ -1,0 +1,11 @@
+package org.camunda.community.rest.client.springboot;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TestApp {
+  public static void main(String[] args) {
+    SpringApplication.run(TestApp.class, args);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.camunda.community</groupId>
     <artifactId>community-hub-release-parent</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
   </parent>
 
   <groupId>org.camunda.community</groupId>
@@ -28,6 +28,66 @@
     <camunda.version>7.20.0</camunda.version>
     <springboot.version>2.7.4</springboot.version>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${springboot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.camunda.bpm</groupId>
+        <artifactId>camunda-bom</artifactId>
+        <version>${camunda.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.openapitools</groupId>
+        <artifactId>jackson-databind-nullable</artifactId>
+        <version>0.2.6</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <version>3.0.2</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>2.14.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.camunda.community</groupId>
+        <artifactId>camunda-engine-rest-client-openapi-java</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.camunda.community</groupId>
+        <artifactId>camunda-engine-rest-client-openapi-springboot</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.openapitools</groupId>
+          <artifactId>openapi-generator-maven-plugin</artifactId>
+          <version>7.0.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.2.1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 
   <modules>
     <module>camunda-engine-rest-client-openapi-java</module>


### PR DESCRIPTION
Instead of the okhttp client with gson, the apache http client with jackson is used.

Also, all version management of dependencies is moved to the parent.