### PR TITLE
Bugfix: Moved to autoconfiguration, moved to eventlistener

### DIFF
--- a/camunda-engine-rest-client-openapi-springboot/src/main/java/org/camunda/community/rest/client/springboot/CamundaApi.java
+++ b/camunda-engine-rest-client-openapi-springboot/src/main/java/org/camunda/community/rest/client/springboot/CamundaApi.java
@@ -4,10 +4,10 @@ package org.camunda.community.rest.client.springboot;
 import org.camunda.community.rest.client.api.*;
 import org.camunda.community.rest.client.invoker.ApiClient;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
+@AutoConfiguration
 public class CamundaApi {
 
     @Autowired

--- a/camunda-engine-rest-client-openapi-springboot/src/main/java/org/camunda/community/rest/client/springboot/CamundaHistoryApi.java
+++ b/camunda-engine-rest-client-openapi-springboot/src/main/java/org/camunda/community/rest/client/springboot/CamundaHistoryApi.java
@@ -3,10 +3,10 @@ package org.camunda.community.rest.client.springboot;
 import org.camunda.community.rest.client.api.*;
 import org.camunda.community.rest.client.invoker.ApiClient;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
+@AutoConfiguration
 public class CamundaHistoryApi {
 
     @Autowired

--- a/camunda-engine-rest-client-openapi-springboot/src/main/java/org/camunda/community/rest/client/springboot/CamundaOpenApiStarter.java
+++ b/camunda-engine-rest-client-openapi-springboot/src/main/java/org/camunda/community/rest/client/springboot/CamundaOpenApiStarter.java
@@ -2,10 +2,10 @@ package org.camunda.community.rest.client.springboot;
 
 import org.camunda.community.rest.client.invoker.ApiClient;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
+@AutoConfiguration
 public class CamundaOpenApiStarter {
 
     @Value( "${camunda.bpm.client.base-url:null}" )

--- a/camunda-engine-rest-client-openapi-springboot/src/main/java/org/camunda/community/rest/client/springboot/CamundaProcessAutodeployment.java
+++ b/camunda-engine-rest-client-openapi-springboot/src/main/java/org/camunda/community/rest/client/springboot/CamundaProcessAutodeployment.java
@@ -5,7 +5,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-import javax.annotation.PostConstruct;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.camunda.community.rest.client.api.DeploymentApi;
@@ -15,6 +14,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.context.event.ApplicationStartedEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.util.DigestUtils;
@@ -25,7 +26,7 @@ import org.springframework.util.DigestUtils;
 @AutoConfiguration
 public class CamundaProcessAutodeployment {
 
-    private Logger logger = LoggerFactory.getLogger(CamundaProcessAutodeployment.class);
+    private static final Logger logger = LoggerFactory.getLogger(CamundaProcessAutodeployment.class);
 
     @Autowired
     private DeploymentApi deploymentApi;
@@ -49,18 +50,18 @@ public class CamundaProcessAutodeployment {
     @Value("${camunda.autoDeploy.enabled:true}")
     private boolean autoDeployEnabled;
 
-    @PostConstruct
+    @EventListener(ApplicationStartedEvent.class)
     public void deployCamundaResources() throws IOException, ApiException {
         if(!autoDeployEnabled){
             return;
         }
-        if (bpmnResourcesPattern==null || bpmnResourcesPattern.length()==0) {
+        if (bpmnResourcesPattern==null || bpmnResourcesPattern.isEmpty()) {
             bpmnResourcesPattern = "classpath*:**/*.bpmn"; // Not sure why the default mechanism in @Value makes problems - but this works!
         }
-        if (dmnResourcesPattern==null || dmnResourcesPattern.length()==0) {
+        if (dmnResourcesPattern==null || dmnResourcesPattern.isEmpty()) {
             dmnResourcesPattern = "classpath*:**/*.dmn";
         }
-        if (formResourcesPattern==null || formResourcesPattern.length()==0) {
+        if (formResourcesPattern==null || formResourcesPattern.isEmpty()) {
             formResourcesPattern = "classpath*:**/*.form";
         }
 

--- a/camunda-engine-rest-client-openapi-springboot/src/main/java/org/camunda/community/rest/client/springboot/CamundaProcessAutodeployment.java
+++ b/camunda-engine-rest-client-openapi-springboot/src/main/java/org/camunda/community/rest/client/springboot/CamundaProcessAutodeployment.java
@@ -1,5 +1,11 @@
 package org.camunda.community.rest.client.springboot;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.PostConstruct;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.camunda.community.rest.client.api.DeploymentApi;
@@ -8,24 +14,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.util.DigestUtils;
 
-import javax.annotation.PostConstruct;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
-
 /**
  * Auto deploys all Camunda resources found on classpath during startup of the application
  */
-@Configuration
+@AutoConfiguration
 public class CamundaProcessAutodeployment {
 
     private Logger logger = LoggerFactory.getLogger(CamundaProcessAutodeployment.class);


### PR DESCRIPTION
Spring Boot 3 relies on jakarta 9+

The `@PostConstruct` annotation comes from Jakarta and was therefore in the namespace `javax` before.

Moving to `@EventListener` will have the same effect while making the whole implementation Jakarta version agnostic.

closes #91 